### PR TITLE
[CHK-1535] Mock to drive transaction status in the final polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,75 @@ It follows 1 digit for send payment result outcome: 1=OK 2=KO
 This is the schema of an RPT id starting with 30201672374
 30201672374<1 digit for send payment result outcome><1 digit for gateway><3 digits for gateway result><2 digits for status>
                               |                              |                      |                          |
-                              |- 1 = OK                      |                      |                          |- as listed before
+                              |-> 1 = OK                     |                      |                          |-> as listed before
                               |                              |                      |
-                              |- 2 = KO                      |                      |
-                                                             |- 1 = XPAY            |
+                              |-> 2 = KO                     |                      |
+                                                             |-> 1 = XPAY           |
                                                              |                      |
-                                                             |- 2 = VPOS            |
-                                                                                    |- XXX= result code based on gateway. It is significant iff the gateway is defined
+                                                             |-> 2 = VPOS           |
+                                                                                    |-> XXX= result code based on gateway. It is significant iff the gateway is defined
+The possible error codes for XPAY are
+
+| RESULT CODE XPAY                                   | ERROR CODE   | RTPID-DIGITS |
+|----------------------------------------------------|--------------|--------------|
+| SUCCESS                                            | 0            | 000          |
+| INCORRECT_PARAMS                                   | 1            | 001          |
+| NOT_FOUND                                          | 2            | 002          |
+| INCORRECT_MAC                                      | 3            | 003          |
+| MAC_NOT_PRESENT                                    | 4            | 004          |
+| TIMEOUT                                            | 5            | 005          |
+| INVALID_APIKEY                                     | 7            | 007          |
+| INVALID_CONTRACT                                   | 8            | 008          |
+| DUPLICATE_TRANSACTION                              | 9            | 009          |
+| INVALID_GROUP                                      | 12           | 012          |
+| TRANSACTION_NOT_FOUND                              | 13           | 013          |
+| EXPIRED_CARD                                       | 14           | 014          |
+| CARD_BRAND_NOT_PERM                                | 15           | 015          |
+| INVALID_STATUS                                     | 16           | 016          |
+| EXCESSIVE_AMOUNT                                   | 17           | 017          |
+| RETRY_EXHAUSTED                                    | 18           | 018          |
+| REFUSED_PAYMENT                                    | 19           | 019          |
+| CANCELED_3DS_AUTH                                  | 20           | 020          |
+| FAILED_3DS_AUTH                                    | 21           | 021          |
+| INVALID_CARD                                       | 22           | 022          |
+| INVALID_MAC_ALIAS                                  | 50           | 050          |
+| KO_RETRIABLE                                       | 96           | 096          |
+| GENERIC_ERROR                                      | 97           | 097          |
+| UNAVAILABLE_METHOD                                 | 98           | 098          |
+| FORBIDDEN_OPERATION                                | 99           | 099          |
+| INTERNAL_ERROR                                     | 100          | 100          |
+
+
+The possible error codes for VPOS are
+
+| RESULT CODE VPOS                                   | ERROR CODE   | RTPID-DIGITS |
+|----------------------------------------------------|--------------|--------------|
+| SUCCESS                                            | 00           | 000          |
+| ORDER_OR_REQREFNUM_NOT_FOUND                       | 01           | 001          |
+| REQREFNUM_INVALID                                  | 02           | 002          |
+| INCORRECT_FORMAT                                   | 03           | 003          |
+| INCORRECT_MAC_OR_TIMESTAMP                         | 04           | 004          |
+| INCORRECT_DATE                                     | 05           | 005          |
+| UNKNOWN_ERROR                                      | 06           | 006          |
+| TRANSACTION_ID_NOT_FOUND                           | 07           | 007          |
+| OPERATOR_NOT_FOUND                                 | 08           | 008          |
+| TRANSACTION_ID_NOT_CONSISTENT                      | 09           | 009          |
+| EXCEEDING_AMOUNT                                   | 10           | 010          |
+| INCORRECT_STATUS                                   | 11           | 011          |
+| CIRCUIT_DISABLED                                   | 12           | 012          |
+| DUPLICATED_ORDER                                   | 13           | 013          |
+| UNSUPPORTED_CURRENCY                               | 16           | 016          |
+| UNSUPPORTED_EXPONENT                               | 17           | 017          |
+| REDIRECTION_3DS1                                   | 20           | 020          |
+| TIMEOUT                                            | 21           | 021          |
+| METHOD_REQUESTED                                   | 25           | 025          |
+| CHALLENGE_REQUESTED                                | 26           | 026          |
+| PAYMENT_INSTRUMENT_NOT_ACCEPTED                    | 35           | 035          |
+| MISSING_CVV2                                       | 37           | 037          |
+| INVALID_PAN                                        | 38           | 038          |
+| XML_EMPTY                                          | 40           | 040          |
+| XML_NOT_PARSABLE                                   | 41           | 041          |
+| INSTALLMENTS_NOT_AVAILABLE                         | 50           | 050          |
+| INSTALLMENT_NUMBER_OUT_OF_BOUNDS                   | 51           | 051          |
+| APPLICATION_ERROR                                  | 98           | 098          |
+| TRANSACTION_FAILED                                 | 99           | 099          |

--- a/README.md
+++ b/README.md
@@ -250,15 +250,12 @@ They follow 1 digit for gateway: 1=XPAY and 2=VPOS
 It follows 1 digit for send payment result outcome: 1=OK 2=KO
 
 This is the schema of an RPT id starting with 30201672374
-30201672374<1 digit for send payment result outcome><1 digit for gateway><3 digits for gateway result><2 digits for status>
-                              |                              |                      |                          |
-                              |-> 1 = OK                     |                      |                          |-> as listed before
-                              |                              |                      |
-                              |-> 2 = KO                     |                      |
-                                                             |-> 1 = XPAY           |
-                                                             |                      |
-                                                             |-> 2 = VPOS           |
-                                                                                    |-> XXX= result code based on gateway. It is significant iff the gateway is defined
+
+| RPT_ID FIRST 11 DIGITS                             | SEND PAYMENT RESULT OUTCOME DIGIT   | GATEWAY DIGIT  | GATEWAY CODE RESULT 3 DIGITS | STATUS DIGITS |
+|----------------------------------------------------|-------------------------------------|----------------|------------------------------|---------------|
+| 30201672374 (NOT FIXED)                            | 1 = OK                              | 1 = XPAY       | XXX (dependant from gateway) | (as listed)   |
+|                                                    | 2 = KO                              | 2 = VPOS       |                              |               |
+
 The possible error codes for XPAY are
 
 | RESULT CODE XPAY                                   | ERROR CODE   | RTPID-DIGITS |
@@ -324,3 +321,24 @@ The possible error codes for VPOS are
 | INSTALLMENT_NUMBER_OUT_OF_BOUNDS                   | 51           | 051          |
 | APPLICATION_ERROR                                  | 98           | 098          |
 | TRANSACTION_FAILED                                 | 99           | 099          |
+
+
+All values for all of these propertiest out of the ranges listed for each of them will be interpreted as UNDEFINED
+
+Example: Rpt id to drive Send payment result OK gateway VPOS result code DUPLICATED_ORDER and final status UNAUTHORIZED
+
+30201672374 (first 11 digits)
+1 (send payment result OK)
+2 (VPOS)
+013 (DUPLICATED ORDER)
+72 (UNAUTHORIZED)
+RPT ID is 302016723741201372
+
+Example: Rpt id to drive Send payment result UNDEFINED gateway XPAY result code TIMEOUT and final status EXPIRED
+
+30201672374 (first 11 digits)
+0 (each values different from1 or 2 are ok) (send payment result UNDEFINED)
+1 (XPAY)
+005 (TIMEOUT)
+68 (EXPIRED)
+RPT ID is 302016723740100568

--- a/README.md
+++ b/README.md
@@ -217,3 +217,31 @@ The ecommerce transaction auth-requests endpoint `/checkout/ecommerce/v1/transac
 | OK                                                 | 200 success case                      |
 | FAIL_AUTH_REQUEST_TRANSACTION_ID_NOT_FOUND         | 404 transactionId not fuond           |
 | FAIL_AUTH_REQUEST_TRANSACTION_ID_ALREADY_PROCESSED | 409 transaction already processed     |   
+
+## Ecommerce final state flow
+The ecommerce transaction get transaction endpoint `/checkout/ecommerce/v1/transactions/:transactionId` is driven by the following cookie mockFlow values:
+
+| COOKIE MOCK FLOW                                   | RptId Suffix |
+|----------------------------------------------------|--------------|
+| NOTIFICATION_REQUESTED                             | 61           |
+| NOTIFICATION_ERROR                                 | 62           |
+| NOTIFIED_KO                                        | 63           |  
+| REFUNDED                                           | 64           |  
+| REFUND_REQUESTED                                   | 65           |  
+| REFUND_ERROR                                       | 66           |  
+| CLOSURE_ERROR                                      | 67           |  
+| EXPIRED                                            | 68           |  
+| EXPIRED_NOT_AUTHORIZED                             | 69           |  
+| CANCELED                                           | 70           |  
+| CANCELLATION_EXPIRED                               | 71           |  
+| UNAUTHORIZED                                       | 72           |  
+
+For some state it is important to evaluate also the following properties:
+ 
+ - Gateway: VPOS or XPAY
+ - Error code: dependant from Gateway (see next two tables)
+ - Send payment result outcome 
+
+also other position of teh rpt id become significant to drive this properties.
+
+/* FINAL STATE MAPPING 30201672374<1 cipher for send payment result outcome><1 cipher for gateway><3 ciphers for gateway result><2 ciphers for status>*/

--- a/README.md
+++ b/README.md
@@ -244,4 +244,18 @@ For some state it is important to evaluate also the following properties:
 
 also other position of teh rpt id become significant to drive this properties.
 
-/* FINAL STATE MAPPING 30201672374<1 cipher for send payment result outcome><1 cipher for gateway><3 ciphers for gateway result><2 ciphers for status>*/
+The last two digits drive the final state (as said from 61 to 72)
+They follow the three digits that drive the gateway result (from 000 to 100)
+They follow 1 digit for gateway: 1=XPAY and 2=VPOS  
+It follows 1 digit for send payment result outcome: 1=OK 2=KO
+
+This is the schema of an RPT id starting with 30201672374
+30201672374<1 digit for send payment result outcome><1 digit for gateway><3 digits for gateway result><2 digits for status>
+                              |                              |                      |                          |
+                              |- 1 = OK                      |                      |                          |- as listed before
+                              |                              |                      |
+                              |- 2 = KO                      |                      |
+                                                             |- 1 = XPAY            |
+                                                             |                      |
+                                                             |- 2 = VPOS            |
+                                                                                    |- XXX= result code based on gateway. It is significant iff the gateway is defined

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "generate": "npm-run-all -s generate:ts-from-yaml:*",
     "generate:ts-from-yaml:api": "shx mkdir -p src/generated/payment_manager && shx mkdir -p src/generated/pagopa_proxy && rimraf src/generated/payment_manager/* && rimraf src/generated/pagopa_proxy/* && gen-api-models --strict 0 --api-spec api_payment_manager.yaml --out-dir src/generated/payment_manager --request-types && gen-api-models --strict 0 --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v1.2.0/api-spec/api-pagopa-proxy.yaml --out-dir src/generated/pagopa_proxy --request-types",
     "generate:ts-from-yaml:pgs": "shx rm -rf src/generated/pgs && shx mkdir -p src/generated/pgs && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/c39cea0b3ac4d992f4bda0026365b5a0eac96802/src/core/api/payment_transactions_gateway_api/external/v1/_openapi.json.tpl --no-strict --out-dir src/generated/pgs",
-    "generate:ts-from-yaml:ecommerce": "shx rm -rf src/generated/ecommerce && shx mkdir -p src/generated/ecommerce && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/main/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl --no-strict --out-dir src/generated/ecommerce"
+    "generate:ts-from-yaml:ecommerce": "shx rm -rf src/generated/ecommerce && shx mkdir -p src/generated/ecommerce && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/CHK-1544-transaction-response-update/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl --no-strict --out-dir src/generated/ecommerce"
   },
   "devDependencies": {
     "@pagopa/eslint-config": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "generate": "npm-run-all -s generate:ts-from-yaml:*",
     "generate:ts-from-yaml:api": "shx mkdir -p src/generated/payment_manager && shx mkdir -p src/generated/pagopa_proxy && rimraf src/generated/payment_manager/* && rimraf src/generated/pagopa_proxy/* && gen-api-models --strict 0 --api-spec api_payment_manager.yaml --out-dir src/generated/payment_manager --request-types && gen-api-models --strict 0 --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v1.2.0/api-spec/api-pagopa-proxy.yaml --out-dir src/generated/pagopa_proxy --request-types",
     "generate:ts-from-yaml:pgs": "shx rm -rf src/generated/pgs && shx mkdir -p src/generated/pgs && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/c39cea0b3ac4d992f4bda0026365b5a0eac96802/src/core/api/payment_transactions_gateway_api/external/v1/_openapi.json.tpl --no-strict --out-dir src/generated/pgs",
-    "generate:ts-from-yaml:ecommerce": "shx rm -rf src/generated/ecommerce && shx mkdir -p src/generated/ecommerce && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/CHK-1544-transaction-response-update/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl --no-strict --out-dir src/generated/ecommerce"
+    "generate:ts-from-yaml:ecommerce": "shx rm -rf src/generated/ecommerce && shx mkdir -p src/generated/ecommerce && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/main/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl --no-strict --out-dir src/generated/ecommerce"
   },
   "devDependencies": {
     "@pagopa/eslint-config": "^1.3.1",

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -4,9 +4,83 @@ import * as E from "fp-ts/Either";
 import { identity, pipe } from "fp-ts/function";
 import { v4 as uuid } from "uuid";
 import { logger } from "./logger";
+import { SendPaymentResultOutcomeEnum } from "./generated/ecommerce/NewTransactionResponse";
 
 const XPAY_OK_PREFIX = "0";
 const XPAY_POLLING_PREFIX = "01";
+
+export enum ErrorCodeCaseVPOS {
+  SUCCESS = "0",
+  INCORRECT_PARAMS = "1",
+  NOT_FOUND = "2",
+  INCORRECT_MAC = "3",
+  MAC_NOT_PRESENT = "4",
+  TIMEOUT = "5",
+  INVALID_APIKEY = "7",
+  INVALID_CONTRACT = "8",
+  DUPLICATE_TRANSACTION = "9",
+  INVALID_GROUP = "12",
+  TRANSACTION_NOT_FOUND = "13",
+  EXPIRED_CARD = "14",
+  CARD_BRAND_NOT_PERMITTED = "15",
+  INVALID_STATUS = "16",
+  EXCESSIVE_AMOUNT = "17",
+  RETRY_EXHAUSTED = "18",
+  REFUSED_PAYMENT = "19",
+  CANCELED_3DS_AUTH = "20",
+  FAILED_3DS_AUTH = "21",
+  INVALID_CARD = "22",
+  INVALID_MAC_ALIAS = "50",
+  KO_RETRIABLE = "96",
+  GENERIC_ERROR = "97",
+  UNAVAILABLE_METHOD = "98",
+  FORBIDDEN_OPERATION = "99",
+  INTERNAL_ERROR = "100"
+}
+
+export enum ErrorCodeCaseXPAY {
+  SUCCESS = "00",
+  ORDER_OR_REQREFNUM_NOT_FOUND = "01",
+  REQREFNUM_INVALID = "02",
+  INCORRECT_FORMAT = "03",
+  INCORRECT_MAC_OR_TIMESTAMP = "04",
+  INCORRECT_DATE = "05",
+  UNKNOWN_ERROR = "06",
+  TRANSACTION_ID_NOT_FOUND = "07",
+  OPERATOR_NOT_FOUND = "08",
+  TRANSACTION_ID_NOT_CONSISTENT = "09",
+  EXCEEDING_AMOUNT = "10",
+  INCORRECT_STATUS = "11",
+  CIRCUIT_DISABLED = "12",
+  DUPLICATED_ORDER = "13",
+  UNSUPPORTED_CURRENCY = "16",
+  UNSUPPORTED_EXPONENT = "17",
+  REDIRECTION_3DS1 = "20",
+  TIMEOUT = "21",
+  METHOD_REQUESTED = "25",
+  CHALLENGE_REQUESTED = "26",
+  PAYMENT_INSTRUMENT_NOT_ACCEPTED = "35",
+  MISSING_CVV2 = "37",
+  INVALID_PAN = "38",
+  XML_EMPTY = "40",
+  XML_NOT_PARSABLE = "41",
+  INSTALLMENTS_NOT_AVAILABLE = "50",
+  INSTALLMENT_NUMBER_OUT_OF_BOUNDS = "51",
+  APPLICATION_ERROR = "98",
+  TRANSACTION_FAILED = "99"
+}
+
+export enum GatewayCase {
+  UNDEFINED,
+  XPAY,
+  VPOS
+}
+
+export enum SendPaymentResultOutcomeCase {
+  UNDEFINED,
+  OK,
+  KO
+}
 
 export enum FlowCase {
   OK,
@@ -79,13 +153,29 @@ export enum FlowCase {
   OK_ABOVETHRESHOLD_CALUCLATE_FEE,
   OK_BELOWTHRESHOLD_CALUCLATE_FEE,
   FAIL_CALCULATE_FEE,
-  /* pagopa-ecommerce: user transaction calcel */
+  /* pagopa-ecommerce: user transaction cancel */
   OK_TRANSACTION_USER_CANCEL,
   ID_NOT_FOUND_TRANSACTION_USER_CANCEL,
-  INTERNAL_SERVER_ERROR_TRANSACTION_USER_CANCEL
+  INTERNAL_SERVER_ERROR_TRANSACTION_USER_CANCEL,
+  /* pagopa-ecommerce: user transaction final state */
+  NOTIFICATION_REQUESTED,
+  NOTIFICATION_ERROR,
+  NOTIFIED_KO,
+  REFUNDED,
+  REFUND_REQUESTED,
+  REFUND_ERROR,
+  CLOSURE_ERROR,
+  EXPIRED_NOT_AUTHORIZED,
+  CANCELED,
+  CANCELLATION_EXPIRED,
+  EXPIRED,
+  UNAUTHORIZED
 }
 
 type FlowCaseKey = keyof typeof FlowCase;
+// type SendPaymentResultOutcomeCaseKey = keyof typeof SendPaymentResultOutcomeCase;
+type GatewayCaseKey = keyof typeof GatewayCase;
+type SendPaymentResultOutcomeEnumKey = keyof typeof SendPaymentResultOutcomeEnum;
 
 export const getFlowFromRptId: (
   rptId: string
@@ -93,6 +183,31 @@ export const getFlowFromRptId: (
   const flowId = Number(rptId.slice(-2));
   if (flowId in FlowCase) {
     return O.some(flowId as FlowCase);
+  } else {
+    return O.none;
+  }
+};
+
+export const getErrorCodeFromRptId: (rptId: string) => string = rptId =>
+  rptId.slice(-5, -2);
+
+export const getGatewayFromRptId: (
+  rptId: string
+) => O.Option<GatewayCase> = rptId => {
+  const flowId = Number(rptId.slice(-6, -5));
+  if (flowId in GatewayCase) {
+    return O.some(flowId as GatewayCase);
+  } else {
+    return O.none;
+  }
+};
+
+export const getSendPaymentResultOutcomeFromRptId: (
+  rptId: string
+) => O.Option<SendPaymentResultOutcomeCase> = rptId => {
+  const flowId = Number(rptId.slice(-7, -6));
+  if (flowId in SendPaymentResultOutcomeCase) {
+    return O.some(flowId as SendPaymentResultOutcomeCase);
   } else {
     return O.none;
   }
@@ -117,12 +232,114 @@ export const getFlowCookie: (req: express.Request) => FlowCase = req =>
     O.getOrElse(() => FlowCase.OK as FlowCase)
   );
 
+export const maybeGetSendPaymentResultCookie: (
+  req: express.Request
+) => O.Option<SendPaymentResultOutcomeEnum> = req =>
+  pipe(
+    O.fromNullable(req.cookies.sendPaymentResult),
+    id => {
+      logger.info(
+        `Request sendPaymentResult cookie: [${req.cookies.sendPaymentResult}]`
+      );
+      return id;
+    },
+    O.filter(id => id in SendPaymentResultOutcomeCase),
+    O.map(
+      (id: SendPaymentResultOutcomeEnumKey) => SendPaymentResultOutcomeEnum[id]
+    )
+  );
+
+export const getSendPaymentResultCookie: (
+  req: express.Request
+) => SendPaymentResultOutcomeEnum = req =>
+  pipe(
+    maybeGetSendPaymentResultCookie(req),
+    O.getOrElse(() => (undefined as unknown) as SendPaymentResultOutcomeEnum)
+  );
+
+export const maybeGetPaymentGatewayCookie: (
+  req: express.Request
+) => O.Option<string> = req =>
+  pipe(
+    O.fromNullable(req.cookies.paymentGateway),
+    id => {
+      logger.info(
+        `Request paymentGateway cookie: [${req.cookies.paymentGateway}]`
+      );
+      return id;
+    },
+    O.filter(id => id in GatewayCase),
+    O.map((id: GatewayCaseKey) => id)
+  );
+
+export const getPaymentGatewayCookie: (req: express.Request) => string = req =>
+  pipe(
+    maybeGetPaymentGatewayCookie(req),
+    O.getOrElse(() => GatewayCase.UNDEFINED.toString())
+  );
+
 export const setFlowCookie: (
   res: express.Response,
   flowId: FlowCase
 ) => void = (res, flowId) => {
   logger.info(`Set mockFlow cookie to: [${FlowCase[flowId]}]`);
   res.cookie("mockFlow", FlowCase[flowId]);
+};
+
+export const setErrorCodeCookie: (
+  res: express.Response,
+  errorCodeId: string,
+  gateway: GatewayCase
+) => void = (res, errorCodeId, gateway) => {
+  switch (GatewayCase[gateway]) {
+    case "XPAY":
+      const errorIdXPAY = ("" + errorCodeId).slice(-2);
+      if (
+        Object.values(ErrorCodeCaseXPAY).filter(v => v === errorIdXPAY)
+          .length === 1
+      ) {
+        logger.info(
+          `Set resultCodeGateway cookie to: [${errorIdXPAY as ErrorCodeCaseXPAY}]`
+        );
+        res.cookie("resultCodeGateway", errorIdXPAY as ErrorCodeCaseXPAY);
+      }
+      break;
+    case "VPOS":
+      const errorIdVPOS = Number(errorCodeId).toString();
+      if (
+        Object.values(ErrorCodeCaseVPOS).filter(v => v === errorIdVPOS)
+          .length === 1
+      ) {
+        logger.info(
+          `Set resultCodeGateway cookie to: [${errorIdVPOS as ErrorCodeCaseVPOS}]`
+        );
+        res.cookie("resultCodeGateway", errorIdVPOS as ErrorCodeCaseVPOS);
+      }
+      break;
+    default:
+      res.clearCookie("resultCodeGateway");
+  }
+};
+
+export const setPaymentGatewayCookie: (
+  res: express.Response,
+  gatewayID: GatewayCase
+) => void = (res, gatewayID) => {
+  logger.info(`Set paymentGateway cookie to: [${GatewayCase[gatewayID]}]`);
+  res.cookie("paymentGateway", GatewayCase[gatewayID]);
+};
+
+export const setSendPaymentResultOutcomeCookie: (
+  res: express.Response,
+  sendPaymentResultId: SendPaymentResultOutcomeCase
+) => void = (res, sendPaymentResultId) => {
+  logger.info(
+    `Set sendPaymentResult cookie to: [${SendPaymentResultOutcomeCase[sendPaymentResultId]}]`
+  );
+  res.cookie(
+    "sendPaymentResult",
+    SendPaymentResultOutcomeCase[sendPaymentResultId]
+  );
 };
 
 export enum XPayFlowCase {
@@ -228,3 +445,33 @@ export const generateTransactionId = (prefix?: number): string =>
     E.toUnion,
     uuidStringValue => uuidStringValue.replace(/-/g, "")
   );
+
+export const generateTransactionIdForEsito = (
+  sendPaymentResultOutcome?: number,
+  gateway?: number,
+  errorCode?: number
+): string => {
+  const sendPaymentResult = pipe(
+    O.fromNullable(sendPaymentResultOutcome),
+    O.map(() => String(sendPaymentResultOutcome)),
+    O.getOrElse(() => "0")
+  );
+
+  const paymentGateway = pipe(
+    O.fromNullable(gateway),
+    O.map(() => String(gateway)),
+    O.getOrElse(() => "0")
+  );
+
+  const error = pipe(
+    O.fromNullable(errorCode),
+    O.map(() => String(gateway)),
+    O.getOrElse(() => "00")
+  );
+  return uuid()
+    .replace(/-/g, "")
+    .substring(0, 28)
+    .concat(error)
+    .concat(paymentGateway)
+    .concat(sendPaymentResult);
+};

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -445,33 +445,3 @@ export const generateTransactionId = (prefix?: number): string =>
     E.toUnion,
     uuidStringValue => uuidStringValue.replace(/-/g, "")
   );
-
-export const generateTransactionIdForEsito = (
-  sendPaymentResultOutcome?: number,
-  gateway?: number,
-  errorCode?: number
-): string => {
-  const sendPaymentResult = pipe(
-    O.fromNullable(sendPaymentResultOutcome),
-    O.map(() => String(sendPaymentResultOutcome)),
-    O.getOrElse(() => "0")
-  );
-
-  const paymentGateway = pipe(
-    O.fromNullable(gateway),
-    O.map(() => String(gateway)),
-    O.getOrElse(() => "0")
-  );
-
-  const error = pipe(
-    O.fromNullable(errorCode),
-    O.map(() => String(gateway)),
-    O.getOrElse(() => "00")
-  );
-  return uuid()
-    .replace(/-/g, "")
-    .substring(0, 28)
-    .concat(error)
-    .concat(paymentGateway)
-    .concat(sendPaymentResult);
-};

--- a/src/handlers/ecommerce/activation.ts
+++ b/src/handlers/ecommerce/activation.ts
@@ -14,7 +14,6 @@ import {
 } from "../../utils/ecommerce/activation";
 import {
   FlowCase,
-  GatewayCase,
   generateTransactionId,
   getErrorCodeFromRptId,
   getFlowFromRptId,
@@ -142,7 +141,7 @@ export const ecommerceActivation: RequestHandler = async (req, res) => {
   const paymentGateway = pipe(
     req.body.paymentNotices[0].rptId,
     getGatewayFromRptId,
-    O.getOrElse(() => GatewayCase.UNDEFINED)
+    O.getOrElseW(() => undefined)
   );
 
   const errorCode = getErrorCodeFromRptId(req.body.paymentNotices[0].rptId);

--- a/src/handlers/ecommerce/activation.ts
+++ b/src/handlers/ecommerce/activation.ts
@@ -14,9 +14,17 @@ import {
 } from "../../utils/ecommerce/activation";
 import {
   FlowCase,
+  GatewayCase,
   generateTransactionId,
+  getErrorCodeFromRptId,
   getFlowFromRptId,
+  getGatewayFromRptId,
+  getSendPaymentResultOutcomeFromRptId,
+  SendPaymentResultOutcomeCase,
+  setErrorCodeCookie,
   setFlowCookie,
+  setPaymentGatewayCookie,
+  setSendPaymentResultOutcomeCookie,
   VposFlowCase,
   XPayFlowCase
 } from "../../flow";
@@ -55,6 +63,21 @@ const activationErrorCase = [
 const authErrorCase = [
   FlowCase.FAIL_AUTH_REQUEST_TRANSACTION_ID_ALREADY_PROCESSED,
   FlowCase.FAIL_AUTH_REQUEST_TRANSACTION_ID_NOT_FOUND
+];
+
+const esitoMappingCase = [
+  FlowCase.NOTIFICATION_REQUESTED,
+  FlowCase.NOTIFICATION_ERROR,
+  FlowCase.NOTIFIED_KO,
+  FlowCase.REFUNDED,
+  FlowCase.REFUND_REQUESTED,
+  FlowCase.REFUND_ERROR,
+  FlowCase.CLOSURE_ERROR,
+  FlowCase.EXPIRED_NOT_AUTHORIZED,
+  FlowCase.CANCELED,
+  FlowCase.CANCELLATION_EXPIRED,
+  FlowCase.EXPIRED,
+  FlowCase.UNAUTHORIZED
 ];
 
 const returnSuccessResponse = (
@@ -109,6 +132,21 @@ export const ecommerceActivation: RequestHandler = async (req, res) => {
     return404ResourceNotFound(res);
     return;
   }
+
+  const sendPaymentResultOutcome = pipe(
+    req.body.paymentNotices[0].rptId,
+    getSendPaymentResultOutcomeFromRptId,
+    O.getOrElse(() => SendPaymentResultOutcomeCase.UNDEFINED)
+  );
+
+  const paymentGateway = pipe(
+    req.body.paymentNotices[0].rptId,
+    getGatewayFromRptId,
+    O.getOrElse(() => GatewayCase.UNDEFINED)
+  );
+
+  const errorCode = getErrorCodeFromRptId(req.body.paymentNotices[0].rptId);
+
   const flowId = pipe(
     req.body.paymentNotices[0].rptId,
     getFlowFromRptId,
@@ -116,7 +154,8 @@ export const ecommerceActivation: RequestHandler = async (req, res) => {
       !authErrorCase.includes(id) &&
       !activationErrorCase.includes(id) &&
       !caluclateFeeCase.includes(id) &&
-      !transactionUserCancelCase.includes(id)
+      !transactionUserCancelCase.includes(id) &&
+      !esitoMappingCase.includes(id)
         ? FlowCase.OK
         : id
     ),
@@ -173,6 +212,9 @@ export const ecommerceActivation: RequestHandler = async (req, res) => {
       break;
     default:
       setFlowCookie(res, flowId);
+      setSendPaymentResultOutcomeCookie(res, sendPaymentResultOutcome);
+      setPaymentGatewayCookie(res, paymentGateway);
+      setErrorCodeCookie(res, errorCode, paymentGateway);
       returnSuccessResponse(req, res);
   }
 };

--- a/src/handlers/ecommerce/transaction.ts
+++ b/src/handlers/ecommerce/transaction.ts
@@ -1,18 +1,179 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { RequestHandler } from "express";
-import { FlowCase, getFlowCookie } from "../../flow";
+import {
+  FlowCase,
+  getFlowCookie,
+  getPaymentGatewayCookie,
+  getSendPaymentResultCookie
+} from "../../flow";
 import { logger } from "../../logger";
 import {
   createSuccessGetTransactionEntity,
   error404TransactionIdNotFound,
   internalServerError500
 } from "../../utils/ecommerce/transaction";
+import { TransactionStatusEnum } from "../../generated/ecommerce/TransactionStatus";
 
 export const ecommerceGetTransaction: RequestHandler = async (req, res) => {
   logger.info("[Get transaction ecommerce] - Return success case");
-  res
-    .status(200)
-    .send(createSuccessGetTransactionEntity(req.params.transactionId));
+  const gateway = getPaymentGatewayCookie(req);
+  const errorCode = undefined;
+  const sendPaymentResultOutcome = getSendPaymentResultCookie(req);
+  switch (getFlowCookie(req)) {
+    case FlowCase.NOTIFICATION_REQUESTED:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.NOTIFICATION_REQUESTED,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.NOTIFICATION_ERROR:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.NOTIFICATION_ERROR,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.NOTIFIED_KO:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.NOTIFIED_KO,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.REFUNDED:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.REFUNDED,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.REFUND_REQUESTED:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.REFUND_REQUESTED,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.REFUND_ERROR:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.REFUND_ERROR,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.CLOSURE_ERROR:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.CLOSURE_ERROR,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.EXPIRED_NOT_AUTHORIZED:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.EXPIRED_NOT_AUTHORIZED,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.CANCELED:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.CANCELED,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.CANCELLATION_EXPIRED:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.CANCELLATION_EXPIRED,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.EXPIRED:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.EXPIRED,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    case FlowCase.UNAUTHORIZED:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.UNAUTHORIZED,
+            gateway,
+            errorCode,
+            sendPaymentResultOutcome
+          )
+        );
+    default:
+      return res
+        .status(200)
+        .send(
+          createSuccessGetTransactionEntity(
+            req.params.transactionId,
+            TransactionStatusEnum.NOTIFIED_OK
+          )
+        );
+  }
 };
 
 const ecommerceDeleteTransaction500 = (res: any): void => {

--- a/src/handlers/ecommerce/transaction.ts
+++ b/src/handlers/ecommerce/transaction.ts
@@ -2,6 +2,7 @@
 import { RequestHandler } from "express";
 import {
   FlowCase,
+  getErrorCodeCookie,
   getFlowCookie,
   getPaymentGatewayCookie,
   getSendPaymentResultCookie
@@ -17,7 +18,7 @@ import { TransactionStatusEnum } from "../../generated/ecommerce/TransactionStat
 export const ecommerceGetTransaction: RequestHandler = async (req, res) => {
   logger.info("[Get transaction ecommerce] - Return success case");
   const gateway = getPaymentGatewayCookie(req);
-  const errorCode = undefined;
+  const errorCode = getErrorCodeCookie(req);
   const sendPaymentResultOutcome = getSendPaymentResultCookie(req);
   switch (getFlowCookie(req)) {
     case FlowCase.NOTIFICATION_REQUESTED:

--- a/src/utils/ecommerce/transaction.ts
+++ b/src/utils/ecommerce/transaction.ts
@@ -1,17 +1,25 @@
+/* eslint-disable max-params */
 import { HttpStatusCode, ProblemJson } from "@pagopa/ts-commons/lib/responses";
 import { AmountEuroCents } from "../../generated/ecommerce/AmountEuroCents";
 import { ClientIdEnum } from "../../generated/ecommerce/NewTransactionResponse";
 import { RptId } from "../../generated/ecommerce/RptId";
 import { TransactionInfo } from "../../generated/ecommerce/TransactionInfo";
 import { TransactionStatusEnum } from "../../generated/ecommerce/TransactionStatus";
+import { SendPaymentResultOutcomeEnum } from "../../generated/ecommerce/NewTransactionResponse";
 
 export const createSuccessGetTransactionEntity = (
-  transactionId: string
+  transactionId: string,
+  status: TransactionStatusEnum,
+  gateway?: string,
+  errorCode?: string,
+  sendPaymentResultOutcome?: SendPaymentResultOutcomeEnum
 ): TransactionInfo => ({
   authToken:
     "eyJhbGciOiJIUzUxMiJ9.eyJ0cmFuc2FjdGlvbklkIjoiMTdhYzhkZTMtMjAzMy00YzQ2LWI1MzQtZjE5MTk2NmNlODRjIiwicnB0SWQiOiI3Nzc3Nzc3Nzc3NzMzMDIwMDAwMDAwMDAwMDAwMCIsImVtYWlsIjoibmFtZS5zdXJuYW1lQHBhZ29wYS5pdCIsInBheW1lbnRUb2tlbiI6IjRkNTAwZTk5MDg3MTQyMDJiNTU3NTFlZDZiMWRmZGYzIiwianRpIjoiODUxNjQ2NDQzMjUxMTQxIn0.Fl3PoDBgtEhDSMFR3unkAow8JAe2ztYDoxlu7h-q_ygmmGvO7zP5dlztELUQCofcmYwhB4L9EgSLNT-HbiJgKA",
   clientId: ClientIdEnum.CHECKOUT,
+  errorCode,
   feeTotal: 99999999,
+  gateway,
   payments: [
     {
       amount: 1000 as AmountEuroCents,
@@ -34,7 +42,8 @@ export const createSuccessGetTransactionEntity = (
       ]
     }
   ],
-  status: TransactionStatusEnum.NOTIFIED_OK,
+  sendPaymentResultOutcome,
+  status,
   transactionId
 });
 


### PR DESCRIPTION
Add mock policy to drive integration test for the final polling

#### List of Changes
Update the readme and the cookie management to make get transaction answer with well known transaction data with info about gateway, send payment result, error code and final status

#### Motivation and Context
Add frontend integration test for final polling

#### How Has This Been Tested?
Test were performed locally and in azure env

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
