### PR TITLE
fix: handle auth request other than cards

### DIFF
--- a/src/handlers/ecommerce/auth-request.ts
+++ b/src/handlers/ecommerce/auth-request.ts
@@ -97,7 +97,6 @@ const processAuthorizationRequest = (req: any, res: any): void => {
               pipe(
                 O.fromNullable(resp.details),
                 O.map(() => {
-                  logger.info("returning mocked response auth request");
                   res
                     .status(200)
                     .send(createSuccessAuthRequestResponseEntity(req)); // Type card invoke PGS

--- a/src/utils/ecommerce/auth-request.ts
+++ b/src/utils/ecommerce/auth-request.ts
@@ -5,9 +5,12 @@ import { HttpStatusCode } from "../../generated/ecommerce/HttpStatusCode";
 const encode = (str: string): string =>
   Buffer.from(str, "binary").toString("base64");
 
-export const createSuccessAuthRequestResponseEntity = (): RequestAuthorizationResponse => ({
+export const createSuccessAuthRequestResponseEntity = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  req: any
+): RequestAuthorizationResponse => ({
   authorizationRequestId: "requestId",
-  authorizationUrl: "https://example.com"
+  authorizationUrl: `${req.protocol}://${req.get("Host")}/esito`
 });
 
 export const createSuccessAuthRequestResponseEntityFromNPG = (_value: {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Handle auth request for methods other that cards. for those methods (detailType != cards) will be returned `esito` outcome url directly, skipping the external domain auth processing jumping directly to outcome page  
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Those modifications allow to test methods other than cards locally with checkout-be-mock (such as wallets, redirect methods ...)
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
local tests with checkout-fe & checkout-be-mock
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
